### PR TITLE
REFAC - Envoie de messages/fichiers (process Publication)

### DIFF
--- a/src/main/java/utils/JDAUtils.java
+++ b/src/main/java/utils/JDAUtils.java
@@ -1,18 +1,24 @@
 package utils;
 
+import models.dao.Server;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.TextChannel;
+import net.dv8tion.jda.api.exceptions.InsufficientPermissionException;
+import org.apache.logging.log4j.Logger;
 
 import javax.security.auth.login.LoginException;
 
 import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 import static utils.EnvironmentVariablesUtils.BOT_TOKEN;
 
 /**
- * Initialisation et récupération de l'instance du {@link JDA}.
+ * Collection d'outils visant à simplifier l'utilisation de la {@link JDA}.
  */
 public class JDAUtils {
-
+  private static final Logger LOGGER = LoggerUtils.buildLogger(JDAUtils.class);
   private static JDA JDA;
 
   /**
@@ -35,5 +41,70 @@ public class JDAUtils {
    */
   public static JDA getJDAInstance() {
     return JDA;
+  }
+
+  /**
+   * Retourne l'objet Guild correspondant à un serveur.
+   * Note: {@link Guild} est la représentation faite d'un serveur Discord par la {@link JDA}.
+   *
+   * @param server Modèle de serveur
+   * @return Instance de {@link Guild} correspondant au serveur donné ou `null` en cas d'erreur.
+   */
+  public static Guild getGuildFromServer(Server server) {
+    try {
+      return JDA.getGuildById(server.getReference());
+    } catch (NumberFormatException | NullPointerException e) {
+      LOGGER.warn("Impossible de récupérer un objet Guild correspondant au serveur '{}'", server.getReference());
+      return null;
+    }
+  }
+
+  /**
+   * Retourne un channel (salon textuel) d'un serveur Discord.
+   *
+   * @param guild   Serveur Discord duquel on souhaite récupérer un channel
+   * @param channel Nom du channel textuel à récupérer
+   * @return Instance de {@link TextChannel} ou `null` en cas d'erreur.
+   */
+  public static TextChannel getTextChannel(Guild guild, String channel) {
+    try {
+      return guild.getTextChannelsByName(channel, true).get(0);
+    } catch (IndexOutOfBoundsException | NullPointerException e) {
+      LOGGER.warn("Le channel '{}' n'existe pas sur le serveur '{}'", channel, guild.getId());
+      return null;
+    }
+  }
+
+  /**
+   * Crée et retourne un channel (salon textuel) sur un serveur Discord.
+   *
+   * @param guild   Serveur Discord surlequel on souhaite créer un channel
+   * @param channel Nom du channel textuel à créer
+   * @return Instance de {@link TextChannel} ou `null` en cas d'erreur.
+   */
+  public static TextChannel createTextChannel(Guild guild, String channel) {
+    try {
+      final TextChannel textChannel = guild.createTextChannel(channel).complete();
+      LOGGER.debug("Channel '{}' créé sur le serveur '{}'", textChannel.getName(), guild.getId());
+      return textChannel;
+    } catch (InsufficientPermissionException e) {
+      LOGGER.warn("Échec de la création du channel '{}' sur le serveur '{}' - Permission refusée", channel, guild.getId());
+    } catch (NullPointerException e) {
+      LOGGER.warn("Échec de la création du channel '{}'", channel);
+    }
+
+    return null;
+  }
+
+  /**
+   * Tente de récupérer un channel d'un serveur Discord, si il n'existe pas il sera créé.
+   *
+   * @param guild   Serveur Discord
+   * @param channel Nom du channel textuel à récupérer
+   * @return Instance de {@link TextChannel} ou `null` en cas d'erreur.
+   */
+  public static TextChannel getOrCreateTextChannel(Guild guild, String channel) {
+    final TextChannel textChannel = getTextChannel(guild, channel);
+    return nonNull(textChannel) ? textChannel : createTextChannel(guild, channel);
   }
 }


### PR DESCRIPTION
Issue à l'origine de cette PR: close #100 

En gros:
- Suppression de `getGuild`, `getChannel` et `createChannel` dans la classe `process.commons.Publication`
- En remplacement, dans la classe `utils.JDAUtils` j'ai ajouté:
https://github.com/loicsteinmetz/alternbot-app/blob/3439f394607b747a5713dfdc545a82844b56961a/src/main/java/utils/JDAUtils.java#L53 https://github.com/loicsteinmetz/alternbot-app/blob/3439f394607b747a5713dfdc545a82844b56961a/src/main/java/utils/JDAUtils.java#L69 https://github.com/loicsteinmetz/alternbot-app/blob/3439f394607b747a5713dfdc545a82844b56961a/src/main/java/utils/JDAUtils.java#L85 https://github.com/loicsteinmetz/alternbot-app/blob/3439f394607b747a5713dfdc545a82844b56961a/src/main/java/utils/JDAUtils.java#L106 Je trouve que ça se justifie par le fait que ces méthodes ne font pas de publication à proprement parler.
- `doSendFile` et `doSendMessage` prennent désormais en paramètre `TextChannel channel`, ça permet d'alléger le code et les diverses vérifications qui étaient parfois redondantes
- Suppression de `sendLongMessage`, même si elle n'était pas en privée je n'ai pas trouvé d'autres utilisation que dans la classe `Publication` elle-même

Pas de modifs sur les tests, je pense que ce n'est pas nécessaire. La manière d'utiliser les fonctions exposées par la classe `Publication` n'a pas changée, c'est du dev "sous le capot". À la rigueur on aurait pu faire tests pour `JDAUtils` mais le package `utils` est exclus du coverage.